### PR TITLE
[FEAT] add perfume filtering by Neo4j note match

### DIFF
--- a/Note/Note.ipynb
+++ b/Note/Note.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "view-in-github"
       },
       "source": [
@@ -12,20 +11,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "metadata": {
-        "id": "W-NGaAUQ5b8-"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "W-NGaAUQ5b8-",
+        "outputId": "7c92768a-721b-4ab5-b81b-51ec620563f8"
       },
       "outputs": [
         {
-          "ename": "ModuleNotFoundError",
-          "evalue": "No module named 'kagglehub'",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-            "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mkagglehub\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;66;03m# Download latest version\u001b[39;00m\n\u001b[1;32m      4\u001b[0m path \u001b[38;5;241m=\u001b[39m kagglehub\u001b[38;5;241m.\u001b[39mdataset_download(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mjoehusseinmama/fragrantica-data\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-            "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'kagglehub'"
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Downloading from https://www.kaggle.com/api/v1/datasets/download/joehusseinmama/fragrantica-data?dataset_version_number=1...\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 1.86G/1.86G [00:17<00:00, 111MB/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Extracting files...\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Path to dataset files: /root/.cache/kagglehub/datasets/joehusseinmama/fragrantica-data/versions/1\n"
           ]
         }
       ],
@@ -40,16 +67,310 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "DjzBnfXELVPj",
+        "outputId": "3fe1252b-beea-41cb-aeab-508ae351d4b2"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Collecting neo4j\n",
+            "  Downloading neo4j-5.28.1-py3-none-any.whl.metadata (5.9 kB)\n",
+            "Requirement already satisfied: pytz in /usr/local/lib/python3.11/dist-packages (from neo4j) (2025.2)\n",
+            "Downloading neo4j-5.28.1-py3-none-any.whl (312 kB)\n",
+            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/312.3 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m\u001b[90m━━━━━━━━━━━\u001b[0m \u001b[32m225.3/312.3 kB\u001b[0m \u001b[31m6.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m312.3/312.3 kB\u001b[0m \u001b[31m5.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: neo4j\n",
+            "Successfully installed neo4j-5.28.1\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install neo4j"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LtdAwei_oEGr"
+      },
+      "source": [
+        "## Neo4j 연결"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "VOgWaol6iygw"
+      },
       "outputs": [],
-      "source": []
+      "source": [
+        "from neo4j import GraphDatabase\n",
+        "\n",
+        "# Neo4j 연결 정보\n",
+        "NEO4J_URI = \n",
+        "NEO4J_USER = \n",
+        "NEO4J_PASSWORD = \n",
+        "\n",
+        "driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3TiNcJNaqayj"
+      },
+      "source": [
+        "## Cypher 쿼리 실행"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "H3T8siwEpTx6",
+        "outputId": "e1b43572-8052-4a7a-a75e-e01dbcb32544"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Title</th>\n",
+              "      <th>Designer</th>\n",
+              "      <th>Description</th>\n",
+              "      <th>Rating</th>\n",
+              "      <th>Notes</th>\n",
+              "      <th>CommonNotes</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Dulce de Leche Ganache Parfums for women and men</td>\n",
+              "      <td>ganache parfums perfumes and colognes</td>\n",
+              "      <td>Dulce de Leche by Ganache Parfums is a Amber Vanilla fragrance for women and men. Dulce de Leche was launched in 2017. The nose behind this fragrance is Jarekhye Covarrubias.</td>\n",
+              "      <td>3.67</td>\n",
+              "      <td>vanilla, milk, sandalwood</td>\n",
+              "      <td>2</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Floralique Avon for women</td>\n",
+              "      <td>avon perfumes and colognes</td>\n",
+              "      <td>Floralique by Avon is a Floral fragrance for women. Floralique was launched in 1995. Top notes are Pineapple, Gardenia and Violet; middle notes are Jasmine, Lily-of-the-Valley and Rose; base notes are Vanilla, Sandalwood and Musk.</td>\n",
+              "      <td>4.00</td>\n",
+              "      <td>rose, jasmine, violet, gardenia, vanilla, sandalwood, musk</td>\n",
+              "      <td>2</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Baby Boy Franck Olivier for men</td>\n",
+              "      <td>franck olivier perfumes and colognes</td>\n",
+              "      <td>Baby Boy by Franck Olivier is a Citrus fragrance for men. This is a new fragrance. Baby Boy was launched in 2022. Top notes are Mandarin Orange and Freesia; middle notes are Orange Blossom, Pear and Peony; base notes are Sandalwood, Heliotrope and Raspberry.</td>\n",
+              "      <td>2.33</td>\n",
+              "      <td>mandarin orange, pear, raspberry, peony, freesia, orange blossom, sandalwood</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Kanat Angela Ciampagna for women and men</td>\n",
+              "      <td>angela ciampagna perfumes and colognes</td>\n",
+              "      <td>Kanat by Angela Ciampagna is a Floral Woody Musk fragrance for women and men. Kanat was launched in 2015. The nose behind this fragrance is Angela Ciampagna. Top notes are Saffron, Bergamot, Apricot, Peach and Black Currant; middle notes are Salt, Magnolia, Cyclamen, Mimosa, Lily and Ylang-Ylang; base notes are Musk, Vanilla and Patchouli.</td>\n",
+              "      <td>3.62</td>\n",
+              "      <td>bergamot, peach, magnolia, ylang-ylang, lily, saffron, vanilla, patchouli, musk</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>Bleu Royal Princesse Marina De Bourbon for women</td>\n",
+              "      <td>princesse marina de bourbon perfumes and colognes</td>\n",
+              "      <td>Bleu Royal by Princesse Marina De Bourbon is a Amber Floral fragrance for women. Bleu Royal was launched in 2012. Top notes are Bergamot, Orange Blossom and Apple; middle notes are Violet, Jasmine and Lotus; base notes are Patchouli, Amber and Sandalwood.</td>\n",
+              "      <td>4.01</td>\n",
+              "      <td>bergamot, apple, jasmine, violet, lotus, orange blossom, sandalwood, patchouli</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>Dalini Anucci for women</td>\n",
+              "      <td>anucci perfumes and colognes</td>\n",
+              "      <td>Dalini by Anucci is a Floral fragrance for women. Dalini was launched during the 1990's.</td>\n",
+              "      <td>4.33</td>\n",
+              "      <td>jasmine, iris, tuberose, sandalwood, patchouli</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>Baroque Fragonard for women</td>\n",
+              "      <td>fragonard perfumes and colognes</td>\n",
+              "      <td>Baroque by Fragonard is a Floral fragrance for women.</td>\n",
+              "      <td>4.19</td>\n",
+              "      <td>bergamot, rose, saffron, ginger, vanilla, guaiac wood, musk</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>Shady Maiora Parfum for women and men</td>\n",
+              "      <td>maiora parfum perfumes and colognes</td>\n",
+              "      <td>Shady by Maiora Parfum is a fragrance for women and men. Shady was launched in 2019. The nose behind this fragrance is Antonio Gigli. Top notes are Mint, Lavender, Nutmeg and elemi; middle notes are Cypress, Sandalwood, Saffron and Cypriol Oil or Nagarmotha; base notes are Amber, Patchouli, Precious Woods and Musk.</td>\n",
+              "      <td>4.22</td>\n",
+              "      <td>mint, nutmeg, saffron, sandalwood, patchouli, musk</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>Classique Love Actually Jean Paul Gaultier for women</td>\n",
+              "      <td>jean paul gaultier perfumes and colognes</td>\n",
+              "      <td>Classique Love Actually by Jean Paul Gaultier is a Amber Floral fragrance for women. Classique Love Actually was launched in 2011. The nose behind this fragrance is Jacques Cavallier. Top notes are Orange Blossom, Star Anise, Pear, Rose and Mandarin Orange; middle notes are Ylang-Ylang, Iris, Orchid, Plum and Ginger; base notes are Amber, Musk and Vanilla.</td>\n",
+              "      <td>4.00</td>\n",
+              "      <td>mandarin orange, pear, plum, rose, iris, orange blossom, ylang-ylang, ginger, vanilla, musk</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>Divine Oriflame for women</td>\n",
+              "      <td>oriflame perfumes and colognes</td>\n",
+              "      <td>Divine by Oriflame is a Floral fragrance for women. Divine was launched in 2002. The nose behind this fragrance is Jean Jacques. Top notes are Bamboo, Violet, Water Hyacinth, Kiwi and Ivy; middle notes are Orchid, Lily, Freesia, Jasmine and Rose; base notes are White Musk, Sandalwood and Plum.</td>\n",
+              "      <td>3.66</td>\n",
+              "      <td>plum, kiwi, rose, jasmine, violet, freesia, lily, sandalwood</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>11</th>\n",
+              "      <td>Tiago Abravanel Mania Jequiti for men</td>\n",
+              "      <td>jequiti perfumes and colognes</td>\n",
+              "      <td>Tiago Abravanel Mania by Jequiti is a Woody Aromatic fragrance for men. Tiago Abravanel Mania was launched in 2018. The nose behind this fragrance is Hernan F챠goli. Top notes are Lemon and Cardamom; middle notes are Lily-of-the-Valley, Anise, Lavender and Geranium; base notes are Cedar, Vanilla and Musk.</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>lemon, cardamom, anise, vanilla, cedar, musk</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12</th>\n",
+              "      <td>Laura Nina's Nature for women</td>\n",
+              "      <td>nina's nature perfumes and colognes</td>\n",
+              "      <td>Laura by Nina's Nature is a Floral fragrance for women. Laura was launched in 2010. The nose behind this fragrance is Nina Judin.</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>orange, jasmine, ylang-ylang, vanilla</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13</th>\n",
+              "      <td>Immortal Oud Mith for women and men</td>\n",
+              "      <td>mith perfumes and colognes</td>\n",
+              "      <td>Immortal Oud by Mith is a Woody fragrance for women and men. This is a new fragrance. Immortal Oud was launched in 2023. Top notes are Orange, Raspberry, Coconut, Cardamom, Pepper and Peach; middle notes are Rose, Dried Fruits, Thyme and Patchouli; base notes are Agarwood (Oud), Vanilla, Tonka Bean, Tobacco, Cacao, Amber and Vetiver.</td>\n",
+              "      <td>4.33</td>\n",
+              "      <td>orange, peach, raspberry, coconut, rose, cardamom, vanilla, patchouli, vetiver, agarwood (oud)</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>14</th>\n",
+              "      <td>Sasora Oud Abdul Samad Al Qurashi for women and men</td>\n",
+              "      <td>abdul samad al qurashi perfumes and colognes</td>\n",
+              "      <td>Sasora Oud by Abdul Samad Al Qurashi is a fragrance for women and men. Top notes are Fruity Notes, Taif Rose and Star Anise; middle notes are Spices and Vanilla; base note is Agarwood (Oud).</td>\n",
+              "      <td>4.83</td>\n",
+              "      <td>vanilla, agarwood (oud)</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>15</th>\n",
+              "      <td>Honey I Washed The Kids Lush for women and men</td>\n",
+              "      <td>lush perfumes and colognes</td>\n",
+              "      <td>Honey I Washed The Kids by Lush is a fragrance for women and men.</td>\n",
+              "      <td>3.84</td>\n",
+              "      <td>bergamot, vanilla, caramel, honey</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>16</th>\n",
+              "      <td>Ginger Mentha No. 1319 C.O.Bigelow for women and men</td>\n",
+              "      <td>c.o.bigelow perfumes and colognes</td>\n",
+              "      <td>Ginger Mentha No. 1319 by C.O.Bigelow is a Aromatic fragrance for women and men. Ginger Mentha No. 1319 was launched in 2009.</td>\n",
+              "      <td>4.00</td>\n",
+              "      <td>mint, ginger, sandalwood</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>17</th>\n",
+              "      <td>Maui Mango Surf Bath & Body Works for women</td>\n",
+              "      <td>bath & body works perfumes and colognes</td>\n",
+              "      <td>Maui Mango Surf by Bath & Body Works is a Floral Fruity Gourmand fragrance for women. Maui Mango Surf was launched in 2015.</td>\n",
+              "      <td>4.00</td>\n",
+              "      <td>sandalwood, musk</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "execution_count": 25,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import pandas as pd\n",
+        "from neo4j import GraphDatabase\n",
+        "from IPython.display import HTML\n",
+        "\n",
+        "# Cypher 쿼리 실행\n",
+        "def run_cypher_query(driver, query: str):\n",
+        "    with driver.session() as session:\n",
+        "        result = session.run(query)\n",
+        "        return [record.data() for record in result]\n",
+        "\n",
+        "# 사용자 선호 노트\n",
+        "liked_notes = ['vanilla', 'amber', 'sandalwood']\n",
+        "note_filter = ', '.join(f'\"{note.lower()}\"' for note in liked_notes)\n",
+        "\n",
+        "# 겹치는 노트가 많은 순으로 정렬\n",
+        "query = f\"\"\"\n",
+        "MATCH (p:Perfume)-[:HAS_NOTE]->(n:Note)\n",
+        "WITH p, COLLECT(n.name) AS allNotes,\n",
+        "     [note IN COLLECT(toLower(n.name)) WHERE note IN [{note_filter}]] AS matchedNotes\n",
+        "WITH p, allNotes, SIZE(matchedNotes) AS matchCount\n",
+        "WHERE matchCount > 0\n",
+        "ORDER BY matchCount DESC\n",
+        "LIMIT 30\n",
+        "RETURN\n",
+        "    p.title AS Title,\n",
+        "    p.designer AS Designer,\n",
+        "    p.description AS Description,\n",
+        "    p.rating AS Rating,\n",
+        "    allNotes AS Notes,\n",
+        "    matchCount AS CommonNotes\n",
+        "\"\"\"\n",
+        "\n",
+        "# 쿼리 실행\n",
+        "recommendations = run_cypher_query(driver, query)\n",
+        "\n",
+        "# DataFrame 변환\n",
+        "df = pd.DataFrame(recommendations)\n",
+        "df['Notes'] = df['Notes'].apply(lambda x: ', '.join(x))\n",
+        "df.index += 1\n",
+        "\n",
+        "# 표 출력\n",
+        "HTML(df.to_html(escape=False))\n"
+      ]
     }
   ],
   "metadata": {
     "colab": {
-      "authorship_tag": "ABX9TyOg3czChaCcD9rbBqy975Dr",
-      "include_colab_link": true,
       "provenance": []
     },
     "kernelspec": {


### PR DESCRIPTION
## 개요
Neo4j에 향수, 노트, 노트 카테고리 그래프를 구성하고 
사용자가 입력한 노트를 기준으로 향수를 필터링하는 기능을 추가했습니다.
공통 노트가 하나 이상인 향수만 결과에 포함됩니다.

## 작업사항
- Neo4j에 다음 노드 및 관계 추가
  - `(:Perfume)`-`[:HAS_NOTE]`->`(:Note)`
  - `(:Note)`-`[:BELONGS_TO]`->`(:NoteCategory)`
- 사용자 노트 입력 기반으로 향수 최대 30개 조회
- 향수 정보(title, designer, description, rating)와 노트 리스트, 겹치는 노트 개수 출력

## 참고
- Neo4j 계정 정보는 노션에 있습니다.

